### PR TITLE
Include SAM CLI in base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:10.3-slim as installer
+FROM debian:bullseye-slim as installer
 RUN apt-get update && apt-get install -y \
     bash \
     curl \
@@ -105,7 +105,7 @@ RUN chmod +x terraform
 # =====
 # Deployer
 #
-FROM node:14
+FROM node:14-bullseye
 # Less and Groff required for some AWS CLI commands (eg: help and cloudfront)
 RUN apt-get update && apt-get install -y \
     groff \

--- a/Dockerfile
+++ b/Dockerfile
@@ -102,6 +102,19 @@ RUN echo "${TERRAFORM_SHA_256}  /terraform.zip" | shasum -c
 RUN unzip /terraform.zip
 RUN chmod +x terraform
 
+# ====
+# AWS Sam Deployer
+#
+# https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html
+FROM installer as samcli
+RUN apt-get update \
+  && apt-get install -y \
+     python3 \
+     python3-pip \
+  && rm -rf /var/lib/apt/lists/*
+RUN pip3 install aws-sam-cli \
+  && rm -rf /root/.cache/pip
+
 # =====
 # Deployer
 #
@@ -119,6 +132,8 @@ COPY --from=awscli /aws-cli-bin/ /usr/local/bin/
 COPY --from=terraform /terraform /usr/local/bin/terraform
 COPY --from=docker /usr/bin/docker /usr/local/bin/docker
 COPY --from=kubeval /usr/local/bin/kubeval /usr/local/bin/kubeval
+COPY --from=samcli /usr/local/bin/sam /usr/local/bin/sam
+COPY --from=samcli /usr/local/lib/python3.9 /usr/local/lib/python3.9
 
 RUN kubectl help > /dev/null
 RUN helm version
@@ -130,6 +145,7 @@ RUN bash --version
 RUN curl --version
 RUN git --version
 RUN jq --version
+RUN sam --version
 
 WORKDIR /config
 CMD bash

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This includes:
 - bash
 - curl
 - git
+- sam
 - jq
 
 # How do I do a new release?


### PR DESCRIPTION
Debian base image was needed not just for the installer, but also for the node instance to be able to run these python packages.

This allows us to run sam cli for deployments and reduces the number of images we need to maintain.