### PR TITLE
Add yq and update docker cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.0] - 2023-10-24
+
+### Changed
+- Upgrade docker to 24.0.6
+- Added yq
+
 ## [1.19.0] - 2023-07-19
 
 ### Changed


### PR DESCRIPTION
The `yq` tool is needed to edit helm yaml files in place. This PR adds the `yq` tool and updates docker to the latest version in order for builds to pass.

yq docs: https://github.com/mikefarah/yq
docker install docs: https://docs.docker.com/engine/install/debian/