### PR TITLE
add kubeconform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.21.0] - 2023-12-11
+
+### Changed
+- Added kubeconform
+
 ## [1.20.0] - 2023-10-24
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -114,6 +114,20 @@ RUN apt-get update \
 RUN pip3 install aws-sam-cli \
   && rm -rf /root/.cache/pip
 
+# =====
+# Kubeconform
+#
+# kubeconform versions may be found at:
+# https://github.com/yannh/kubeconform/releases
+FROM installer as kubeconform
+ENV KUBECONFORM_URL="https://github.com/yannh/kubeconform/releases/download/v0.6.4/kubeconform-linux-amd64.tar.gz"
+RUN curl -Ls "${KUBECONFORM_URL}" > kubeconform.tar.gz
+RUN tar -xvzf kubeconform.tar.gz
+RUN mv kubeconform /usr/local/bin/kubeconform
+ENV KUBECONFORM_SHA_256=d095722bf8032abec604dbb2c68f7c77fee55a5b770d1f96d5e3988b3c5faae5
+RUN echo "${KUBECONFORM_SHA_256}  /usr/local/bin/kubeconform" | shasum -a 256 -c
+RUN chmod +x /usr/local/bin/kubeconform
+
 # ====
 # General Tools
 #
@@ -141,6 +155,7 @@ COPY --from=awscli /aws-cli-bin/ /usr/local/bin/
 COPY --from=terraform /terraform /usr/local/bin/terraform
 COPY --from=docker /usr/bin/docker /usr/local/bin/docker
 COPY --from=kubeval /usr/local/bin/kubeval /usr/local/bin/kubeval
+COPY --from=kubeconform /usr/local/bin/kubeconform /usr/local/bin/kubeconform
 COPY --from=samcli /usr/local/bin/sam /usr/local/bin/sam
 COPY --from=samcli /usr/local/lib/python3.9 /usr/local/lib/python3.9
 COPY --from=tools /yq /usr/local/bin/yq
@@ -148,6 +163,7 @@ COPY --from=tools /yq /usr/local/bin/yq
 RUN kubectl help > /dev/null
 RUN helm version
 RUN kubeval --version
+RUN kubeconform -v
 RUN aws --version
 RUN terraform version
 RUN docker --version


### PR DESCRIPTION
The kubernetes manifest validation tool kubeval is no longer maintained. The recommendation is to use kubeconform instead. This PR adds kubeconform to the kube-deployer image.

Build: https://github.com/centrapay/kube-deployer/actions/runs/7161374574/job/19496893768

How to test:
- Build the image and see that kubeconform is added